### PR TITLE
Fix shift amount width in fma and fma_multi - bug triggered by fp8alt

### DIFF
--- a/src/fpnew_fma.sv
+++ b/src/fpnew_fma.sv
@@ -66,8 +66,8 @@ module fpnew_fma #(
   // datapath leakage. This is either given by the exponent bits or the width of the LZC result.
   // In most reasonable FP formats the internal exponent will be wider than the LZC result.
   localparam int unsigned EXP_WIDTH = unsigned'(fpnew_pkg::maximum(EXP_BITS + 2, LZC_RESULT_WIDTH));
-  // Shift amount width: maximum internal mantissa size is 3p+3 bits
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 3);
+  // Shift amount width: maximum internal mantissa size is 3p+4 bits
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 5);
   // Pipelines
   localparam NUM_INP_REGS = PipeConfig == fpnew_pkg::BEFORE
                             ? NumPipeRegs

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -72,8 +72,8 @@ module fpnew_fma_multi #(
   // datapath leakage. This is either given by the exponent bits or the width of the LZC result.
   // In most reasonable FP formats the internal exponent will be wider than the LZC result.
   localparam int unsigned EXP_WIDTH = fpnew_pkg::maximum(SUPER_EXP_BITS + 2, LZC_RESULT_WIDTH);
-  // Shift amount width: maximum internal mantissa size is 3p+3 bits
-  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 3);
+  // Shift amount width: maximum internal mantissa size is 3p+4 bits
+  localparam int unsigned SHIFT_AMOUNT_WIDTH = $clog2(3 * PRECISION_BITS + 5);
   // Pipelines
   localparam NUM_INP_REGS = PipeConfig == fpnew_pkg::BEFORE
                             ? NumPipeRegs


### PR DESCRIPTION
Fix bug in `fpnew_fma` and `fpnew_fma_multi` triggered by the `FP8ALT` format. The `SHIFT_AMOUNT_WIDTH` parameter was not large enough to represent the maximum shift.

`SHIFT_AMOUNT_WIDTH` is used to define `addend_shamt` as `logic [SHIFT_AMOUNT_WIDTH-1:0] addend_shamt;`.
The maximum value we need to represent with `addend_shamt` is `3 * PRECISION_BITS + 4`. Therefore, we need to define `SHIFT_AMOUNT_WIDTH = $clog2 (3 * PRECISION_BITS +5)`. (`$clog2 (3 * PRECISION_BITS +4`) would not be enough if `3 * PRECISION_BITS +4` is a power of two).