### PR TITLE
Fix and extend `fpnew` SIMD support (Ara Vector processor branch)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,9 +12,15 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 
 ### Added
 - Citation file `CITATION.cff`
+- Add support for RISC-V compliant classify in vectorial mode when the vector element width is at least 10 bits
+- Add `mask` input signal to mask exceptions from inactive SIMD elements
+- Add support for rounding toward odd (RISC-V V 1.0 compliant)
+
 ### Changed
 - Code ownership to @lucabertaccini
+
 ### Fixed
+- Fix de-synchronization among vectorial lanes during variable-latency operations (`fdiv`, `fsqrt`)
 
 
 ## [0.6.6] - 2021-04-19

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,9 @@ For more in-depth explanations on how to configure the unit and the layout of th
 | `Features`       | Specifies the features of the FPU, such as the set of supported formats and operations.                                      |
 | `Implementation` | Allows to control how the above features are implemented, such as the number of pipeline stages and architecture of subunits |
 | `TagType`        | The SystemVerilog data type of the operation tag                                                                             |
+| `MaskType`       | The SystemVerilog data type of the mask vector                                                                               |
+| `TrueSIMDClass`  | If enabled, the result of a classify operation in vectorial mode will be RISC-V compliant if each output has at least 10 bits|
+| `NumLanes`*      | Number of vectorial lanes in the system (this parameter is derived, and it is not supposed to be changed by the user)        |
 
 
 ### Ports
@@ -58,6 +61,7 @@ As the width of some input/output signals is defined by the configuration, it is
 | `int_fmt_i`      | in        | `int_format_e`       | Integer format                                                 |
 | `vectorial_op_i` | in        | `logic`              | Vectorial operation select                                     |
 | `tag_i`          | in        | `TagType`            | Operation tag input                                            |
+| `simd_mask_i`    | in        | `MaskType`           | Vector mask input                                              |
 | `in_valid_i`     | in        | `logic`              | Input data valid (see [Handshake](#handshake-interface))       |
 | `in_ready_o`     | out       | `logic`              | Input interface ready (see [Handshake](#handshake-interface))  |
 | `flush_i`        | in        | `logic`              | Synchronous pipeline reset                                     |
@@ -84,6 +88,7 @@ Enumeration of type `logic [2:0]` holding available rounding modes, encoded for 
 | `RDN`      | `3'b010` | Toward negative infinity                             |
 | `RUP`      | `3'b011` | Toward positive infinity                             |
 | `RMM`      | `3'b100` | To nearest, tie away from zero                       |
+| `ROD`      | `3'b101` | To odd                                               |
 | `DYN`      | `3'b111` | *RISC-V Dynamic RM, invalid if passed to operations* |
 
 ##### `operation_e` - FP Operation

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,13 +24,13 @@ FPnew is a parametric floating-point unit which supports standard RISC-V operati
 The top-level module of the FPU is `fpnew_top` and its interface is further described in this section.
 FPnew uses a synchronous interface using handshaking to transfer data into and out of the FPU.
 
-All array types are packed due to poor support of unpacked arrays in some EDA tools.  
+All array types are packed due to poor support of unpacked arrays in some EDA tools.
 SystemVerilog `interface`s are not used due to poor support in some EDA tools.
 
 
 ### Parameters
 
-The configuration parameters use data types defined in `fpnew_pkg` which are structs containing multi-dimensional arrays of custom enumeration types.  
+The configuration parameters use data types defined in `fpnew_pkg` which are structs containing multi-dimensional arrays of custom enumeration types.
 For more in-depth explanations on how to configure the unit and the layout of the types used, please refer to the [Configuration Section](#configuration).
 
 |  Parameter Name  |                                                         Description                                                          |
@@ -38,14 +38,12 @@ For more in-depth explanations on how to configure the unit and the layout of th
 | `Features`       | Specifies the features of the FPU, such as the set of supported formats and operations.                                      |
 | `Implementation` | Allows to control how the above features are implemented, such as the number of pipeline stages and architecture of subunits |
 | `TagType`        | The SystemVerilog data type of the operation tag                                                                             |
-| `MaskType`       | The SystemVerilog data type of the mask vector                                                                               |
 | `TrueSIMDClass`  | If enabled, the result of a classify operation in vectorial mode will be RISC-V compliant if each output has at least 10 bits|
-| `NumLanes`*      | Number of vectorial lanes in the system (this parameter is derived, and it is not supposed to be changed by the user)        |
-
+| `EnableSIMDMask` | Enable the RISC-V floating-point status flags masking of inactive vectorial lanes. When disabled, `simd_mask_i` is inactive  |
 
 ### Ports
 
-Many ports use custom types and enumerations from `fpnew_pkg` to improve code structure internally (see [Data Types](#data-types)).  
+Many ports use custom types and enumerations from `fpnew_pkg` to improve code structure internally (see [Data Types](#data-types)).
 As the width of some input/output signals is defined by the configuration, it is denoted `W` in the following table.
 
 |    Port Name     | Direction |         Type         |                          Description                           |
@@ -61,7 +59,7 @@ As the width of some input/output signals is defined by the configuration, it is
 | `int_fmt_i`      | in        | `int_format_e`       | Integer format                                                 |
 | `vectorial_op_i` | in        | `logic`              | Vectorial operation select                                     |
 | `tag_i`          | in        | `TagType`            | Operation tag input                                            |
-| `simd_mask_i`    | in        | `MaskType`           | Vector mask input                                              |
+| `simd_mask_i`    | in        | `MaskType`           | Vector mask input for the status flags                         |
 | `in_valid_i`     | in        | `logic`              | Input data valid (see [Handshake](#handshake-interface))       |
 | `in_ready_o`     | out       | `logic`              | Input interface ready (see [Handshake](#handshake-interface))  |
 | `flush_i`        | in        | `logic`              | Synchronous pipeline reset                                     |
@@ -202,6 +200,10 @@ Tags are an optional feature of FPnew and can be controlled by setting the `TagT
 In order to disable the use of tags, set `TagType` to `logic` (the default value), and bind the `tag_i` port to a static value.
 Furthermore ensure that your synthesis tool removes static registers.
 
+### Mask for the status flags
+
+This input is meant to be used in vectorial mode. The mask for the status flags is an input vector with `NumLanes` bits, and each bit can mask the status flags of a different FPU vectorial lane. This helps not make the final output flag signal dirty due to status flags from inactive lanes.
+If `simd_mask_i[n] == 1'b0`, the `n`th FPU lane will be masked for this operation and its resulting status flags will not be propagated to the final output status flag.
 
 ## Configuration
 
@@ -329,7 +331,7 @@ Currently, the follwoing unit types are available for the FPU operation groups:
   '{default: MERGED},   // DIVSQRT
   '{default: PARALLEL}, // NONCOMP
   '{default: MERGED}}   // CONV`
-``` 
+```
 (all formats within operation group use same type)
 
 
@@ -353,7 +355,7 @@ The configuration  `pipe_config_t` is an enumeration of type `logic [1:0]` holdi
 ### Adding Custom Formats
 
 In order to add custom FP or integer formats to the FPU, it is necessary to make small changes to `fpnew_pkg`.
-New formats can easily be added by extending the default list of available formats, and/or by changing or removing the defaults. 
+New formats can easily be added by extending the default list of available formats, and/or by changing or removing the defaults.
 
 Namely, the following parameters and types shall be adapted:
 ```

--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -35,6 +35,7 @@ module fpnew_divsqrt_multi #(
   input  fpnew_pkg::operation_e       op_i,
   input  fpnew_pkg::fp_format_e       dst_fmt_i,
   input  TagType                      tag_i,
+  input  logic                        mask_i,
   input  AuxType                      aux_i,
   // Input Handshake
   input  logic                        in_valid_i,
@@ -45,6 +46,7 @@ module fpnew_divsqrt_multi #(
   output fpnew_pkg::status_t          status_o,
   output logic                        extension_bit_o,
   output TagType                      tag_o,
+  output logic                        mask_o,
   output AuxType                      aux_o,
   // Output handshake
   output logic                        out_valid_o,
@@ -84,6 +86,7 @@ module fpnew_divsqrt_multi #(
   fpnew_pkg::operation_e [0:NUM_INP_REGS]                       inp_pipe_op_q;
   fpnew_pkg::fp_format_e [0:NUM_INP_REGS]                       inp_pipe_dst_fmt_q;
   TagType                [0:NUM_INP_REGS]                       inp_pipe_tag_q;
+  logic                  [0:NUM_INP_REGS]                       inp_pipe_mask_q;
   AuxType                [0:NUM_INP_REGS]                       inp_pipe_aux_q;
   logic                  [0:NUM_INP_REGS]                       inp_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -95,6 +98,7 @@ module fpnew_divsqrt_multi #(
   assign inp_pipe_op_q[0]       = op_i;
   assign inp_pipe_dst_fmt_q[0]  = dst_fmt_i;
   assign inp_pipe_tag_q[0]      = tag_i;
+  assign inp_pipe_mask_q[0]     = mask_i;
   assign inp_pipe_aux_q[0]      = aux_i;
   assign inp_pipe_valid_q[0]    = in_valid_i;
   // Input stage: Propagate pipeline ready signal to updtream circuitry
@@ -117,6 +121,7 @@ module fpnew_divsqrt_multi #(
     `FFL(inp_pipe_op_q[i+1],       inp_pipe_op_q[i],       reg_ena, fpnew_pkg::FMADD)
     `FFL(inp_pipe_dst_fmt_q[i+1],  inp_pipe_dst_fmt_q[i],  reg_ena, fpnew_pkg::fp_format_e'(0))
     `FFL(inp_pipe_tag_q[i+1],      inp_pipe_tag_q[i],      reg_ena, TagType'('0))
+    `FFL(inp_pipe_mask_q[i+1],     inp_pipe_mask_q[i],     reg_ena, '0)
     `FFL(inp_pipe_aux_q[i+1],      inp_pipe_aux_q[i],      reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
@@ -244,11 +249,13 @@ module fpnew_divsqrt_multi #(
   // Hold additional information while the operation is in progress
   logic result_is_fp8_q;
   TagType result_tag_q;
+  logic result_mask_q;
   AuxType result_aux_q;
 
   // Fill the registers everytime a valid operation arrives (load FF, active low asynch rst)
   `FFL(result_is_fp8_q, input_is_fp8,                 op_starting, '0)
   `FFL(result_tag_q,    inp_pipe_tag_q[NUM_INP_REGS], op_starting, '0)
+  `FFL(result_mask_q,   inp_pipe_mask_q[NUM_INP_REGS],op_starting, '0)
   `FFL(result_aux_q,    inp_pipe_aux_q[NUM_INP_REGS], op_starting, '0)
 
   // -----------------
@@ -298,6 +305,7 @@ module fpnew_divsqrt_multi #(
   logic               [0:NUM_OUT_REGS][WIDTH-1:0] out_pipe_result_q;
   fpnew_pkg::status_t [0:NUM_OUT_REGS]            out_pipe_status_q;
   TagType             [0:NUM_OUT_REGS]            out_pipe_tag_q;
+  logic               [0:NUM_OUT_REGS]            out_pipe_mask_q;
   AuxType             [0:NUM_OUT_REGS]            out_pipe_aux_q;
   logic               [0:NUM_OUT_REGS]            out_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -307,6 +315,7 @@ module fpnew_divsqrt_multi #(
   assign out_pipe_result_q[0] = result_d;
   assign out_pipe_status_q[0] = status_d;
   assign out_pipe_tag_q[0]    = result_tag_q;
+  assign out_pipe_mask_q[0]   = result_mask_q;
   assign out_pipe_aux_q[0]    = result_aux_q;
   assign out_pipe_valid_q[0]  = out_valid;
   // Input stage: Propagate pipeline ready signal to inside pipe
@@ -327,6 +336,7 @@ module fpnew_divsqrt_multi #(
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)
     `FFL(out_pipe_tag_q[i+1],    out_pipe_tag_q[i],    reg_ena, TagType'('0))
+    `FFL(out_pipe_mask_q[i+1],   out_pipe_mask_q[i],   reg_ena, '0)
     `FFL(out_pipe_aux_q[i+1],    out_pipe_aux_q[i],    reg_ena, AuxType'('0))
   end
   // Output stage: Ready travels backwards from output side, driven by downstream circuitry
@@ -336,6 +346,7 @@ module fpnew_divsqrt_multi #(
   assign status_o        = out_pipe_status_q[NUM_OUT_REGS];
   assign extension_bit_o = 1'b1; // always NaN-Box result
   assign tag_o           = out_pipe_tag_q[NUM_OUT_REGS];
+  assign mask_o          = out_pipe_mask_q[NUM_OUT_REGS];
   assign aux_o           = out_pipe_aux_q[NUM_OUT_REGS];
   assign out_valid_o     = out_pipe_valid_q[NUM_OUT_REGS];
   assign busy_o          = (| {inp_pipe_valid_q, unit_busy, out_pipe_valid_q});

--- a/src/fpnew_fma.sv
+++ b/src/fpnew_fma.sv
@@ -33,6 +33,7 @@ module fpnew_fma #(
   input fpnew_pkg::operation_e     op_i,
   input logic                      op_mod_i,
   input TagType                    tag_i,
+  input logic                      mask_i,
   input AuxType                    aux_i,
   // Input Handshake
   input  logic                     in_valid_i,
@@ -43,6 +44,7 @@ module fpnew_fma #(
   output fpnew_pkg::status_t       status_o,
   output logic                     extension_bit_o,
   output TagType                   tag_o,
+  output logic                     mask_o,
   output AuxType                   aux_o,
   // Output handshake
   output logic                     out_valid_o,
@@ -104,6 +106,7 @@ module fpnew_fma #(
   fpnew_pkg::operation_e [0:NUM_INP_REGS]                 inp_pipe_op_q;
   logic                  [0:NUM_INP_REGS]                 inp_pipe_op_mod_q;
   TagType                [0:NUM_INP_REGS]                 inp_pipe_tag_q;
+  logic                  [0:NUM_INP_REGS]                 inp_pipe_mask_q;
   AuxType                [0:NUM_INP_REGS]                 inp_pipe_aux_q;
   logic                  [0:NUM_INP_REGS]                 inp_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -116,6 +119,7 @@ module fpnew_fma #(
   assign inp_pipe_op_q[0]       = op_i;
   assign inp_pipe_op_mod_q[0]   = op_mod_i;
   assign inp_pipe_tag_q[0]      = tag_i;
+  assign inp_pipe_mask_q[0]     = mask_i;
   assign inp_pipe_aux_q[0]      = aux_i;
   assign inp_pipe_valid_q[0]    = in_valid_i;
   // Input stage: Propagate pipeline ready signal to updtream circuitry
@@ -139,6 +143,7 @@ module fpnew_fma #(
     `FFL(inp_pipe_op_q[i+1],       inp_pipe_op_q[i],       reg_ena, fpnew_pkg::FMADD)
     `FFL(inp_pipe_op_mod_q[i+1],   inp_pipe_op_mod_q[i],   reg_ena, '0)
     `FFL(inp_pipe_tag_q[i+1],      inp_pipe_tag_q[i],      reg_ena, TagType'('0))
+    `FFL(inp_pipe_mask_q[i+1],     inp_pipe_mask_q[i],     reg_ena, '0)
     `FFL(inp_pipe_aux_q[i+1],      inp_pipe_aux_q[i],      reg_ena, AuxType'('0))
   end
 
@@ -408,6 +413,7 @@ module fpnew_fma #(
   fp_t                   [0:NUM_MID_REGS]                         mid_pipe_spec_res_q;
   fpnew_pkg::status_t    [0:NUM_MID_REGS]                         mid_pipe_spec_stat_q;
   TagType                [0:NUM_MID_REGS]                         mid_pipe_tag_q;
+  logic                  [0:NUM_MID_REGS]                         mid_pipe_mask_q;
   AuxType                [0:NUM_MID_REGS]                         mid_pipe_aux_q;
   logic                  [0:NUM_MID_REGS]                         mid_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -427,6 +433,7 @@ module fpnew_fma #(
   assign mid_pipe_spec_res_q[0]    = special_result;
   assign mid_pipe_spec_stat_q[0]   = special_status;
   assign mid_pipe_tag_q[0]         = inp_pipe_tag_q[NUM_INP_REGS];
+  assign mid_pipe_mask_q[0]        = inp_pipe_mask_q[NUM_INP_REGS];
   assign mid_pipe_aux_q[0]         = inp_pipe_aux_q[NUM_INP_REGS];
   assign mid_pipe_valid_q[0]       = inp_pipe_valid_q[NUM_INP_REGS];
   // Input stage: Propagate pipeline ready signal to input pipe
@@ -458,6 +465,7 @@ module fpnew_fma #(
     `FFL(mid_pipe_spec_res_q[i+1],    mid_pipe_spec_res_q[i],    reg_ena, '0)
     `FFL(mid_pipe_spec_stat_q[i+1],   mid_pipe_spec_stat_q[i],   reg_ena, '0)
     `FFL(mid_pipe_tag_q[i+1],         mid_pipe_tag_q[i],         reg_ena, TagType'('0))
+    `FFL(mid_pipe_mask_q[i+1],        mid_pipe_mask_q[i],        reg_ena, '0)
     `FFL(mid_pipe_aux_q[i+1],         mid_pipe_aux_q[i],         reg_ena, AuxType'('0))
   end
   // Output stage: assign selected pipe outputs to signals for later use
@@ -634,6 +642,7 @@ module fpnew_fma #(
   fp_t                [0:NUM_OUT_REGS] out_pipe_result_q;
   fpnew_pkg::status_t [0:NUM_OUT_REGS] out_pipe_status_q;
   TagType             [0:NUM_OUT_REGS] out_pipe_tag_q;
+  logic               [0:NUM_OUT_REGS] out_pipe_mask_q;
   AuxType             [0:NUM_OUT_REGS] out_pipe_aux_q;
   logic               [0:NUM_OUT_REGS] out_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -643,6 +652,7 @@ module fpnew_fma #(
   assign out_pipe_result_q[0] = result_d;
   assign out_pipe_status_q[0] = status_d;
   assign out_pipe_tag_q[0]    = mid_pipe_tag_q[NUM_MID_REGS];
+  assign out_pipe_mask_q[0]   = mid_pipe_mask_q[NUM_MID_REGS];
   assign out_pipe_aux_q[0]    = mid_pipe_aux_q[NUM_MID_REGS];
   assign out_pipe_valid_q[0]  = mid_pipe_valid_q[NUM_MID_REGS];
   // Input stage: Propagate pipeline ready signal to inside pipe
@@ -663,6 +673,7 @@ module fpnew_fma #(
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)
     `FFL(out_pipe_tag_q[i+1],    out_pipe_tag_q[i],    reg_ena, TagType'('0))
+    `FFL(out_pipe_mask_q[i+1],   out_pipe_mask_q[i],   reg_ena, '0)
     `FFL(out_pipe_aux_q[i+1],    out_pipe_aux_q[i],    reg_ena, AuxType'('0))
   end
   // Output stage: Ready travels backwards from output side, driven by downstream circuitry
@@ -672,6 +683,7 @@ module fpnew_fma #(
   assign status_o        = out_pipe_status_q[NUM_OUT_REGS];
   assign extension_bit_o = 1'b1; // always NaN-Box result
   assign tag_o           = out_pipe_tag_q[NUM_OUT_REGS];
+  assign mask_o          = out_pipe_mask_q[NUM_OUT_REGS];
   assign aux_o           = out_pipe_aux_q[NUM_OUT_REGS];
   assign out_valid_o     = out_pipe_valid_q[NUM_OUT_REGS];
   assign busy_o          = (| {inp_pipe_valid_q, mid_pipe_valid_q, out_pipe_valid_q});

--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -33,6 +33,7 @@ module fpnew_noncomp #(
   input fpnew_pkg::operation_e     op_i,
   input logic                      op_mod_i,
   input TagType                    tag_i,
+  input logic                      mask_i,
   input AuxType                    aux_i,
   // Input Handshake
   input  logic                     in_valid_i,
@@ -45,6 +46,7 @@ module fpnew_noncomp #(
   output fpnew_pkg::classmask_e    class_mask_o,
   output logic                     is_class_o,
   output TagType                   tag_o,
+  output logic                     mask_o,
   output AuxType                   aux_o,
   // Output handshake
   output logic                     out_valid_o,
@@ -89,6 +91,7 @@ module fpnew_noncomp #(
   fpnew_pkg::operation_e [0:NUM_INP_REGS]                 inp_pipe_op_q;
   logic                  [0:NUM_INP_REGS]                 inp_pipe_op_mod_q;
   TagType                [0:NUM_INP_REGS]                 inp_pipe_tag_q;
+  logic                  [0:NUM_INP_REGS]                 inp_pipe_mask_q;
   AuxType                [0:NUM_INP_REGS]                 inp_pipe_aux_q;
   logic                  [0:NUM_INP_REGS]                 inp_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -101,6 +104,7 @@ module fpnew_noncomp #(
   assign inp_pipe_op_q[0]       = op_i;
   assign inp_pipe_op_mod_q[0]   = op_mod_i;
   assign inp_pipe_tag_q[0]      = tag_i;
+  assign inp_pipe_mask_q[0]     = mask_i;
   assign inp_pipe_aux_q[0]      = aux_i;
   assign inp_pipe_valid_q[0]    = in_valid_i;
   // Input stage: Propagate pipeline ready signal to updtream circuitry
@@ -124,6 +128,7 @@ module fpnew_noncomp #(
     `FFL(inp_pipe_op_q[i+1],       inp_pipe_op_q[i],       reg_ena, fpnew_pkg::FMADD)
     `FFL(inp_pipe_op_mod_q[i+1],   inp_pipe_op_mod_q[i],   reg_ena, '0)
     `FFL(inp_pipe_tag_q[i+1],      inp_pipe_tag_q[i],      reg_ena, TagType'('0))
+    `FFL(inp_pipe_mask_q[i+1],     inp_pipe_mask_q[i],     reg_ena, '0)
     `FFL(inp_pipe_aux_q[i+1],      inp_pipe_aux_q[i],      reg_ena, AuxType'('0))
   end
 
@@ -354,6 +359,7 @@ module fpnew_noncomp #(
   fpnew_pkg::classmask_e [0:NUM_OUT_REGS] out_pipe_class_mask_q;
   logic                  [0:NUM_OUT_REGS] out_pipe_is_class_q;
   TagType                [0:NUM_OUT_REGS] out_pipe_tag_q;
+  logic                  [0:NUM_OUT_REGS] out_pipe_mask_q;
   AuxType                [0:NUM_OUT_REGS] out_pipe_aux_q;
   logic                  [0:NUM_OUT_REGS] out_pipe_valid_q;
   // Ready signal is combinatorial for all stages
@@ -366,6 +372,7 @@ module fpnew_noncomp #(
   assign out_pipe_class_mask_q[0]    = class_mask_d;
   assign out_pipe_is_class_q[0]      = is_class_d;
   assign out_pipe_tag_q[0]           = inp_pipe_tag_q[NUM_INP_REGS];
+  assign out_pipe_mask_q[0]          = inp_pipe_mask_q[NUM_INP_REGS];
   assign out_pipe_aux_q[0]           = inp_pipe_aux_q[NUM_INP_REGS];
   assign out_pipe_valid_q[0]         = inp_pipe_valid_q[NUM_INP_REGS];
   // Input stage: Propagate pipeline ready signal to inside pipe
@@ -389,6 +396,7 @@ module fpnew_noncomp #(
     `FFL(out_pipe_class_mask_q[i+1],    out_pipe_class_mask_q[i],    reg_ena, fpnew_pkg::QNAN)
     `FFL(out_pipe_is_class_q[i+1],      out_pipe_is_class_q[i],      reg_ena, '0)
     `FFL(out_pipe_tag_q[i+1],           out_pipe_tag_q[i],           reg_ena, TagType'('0))
+    `FFL(out_pipe_mask_q[i+1],          out_pipe_mask_q[i],          reg_ena, '0)
     `FFL(out_pipe_aux_q[i+1],           out_pipe_aux_q[i],           reg_ena, AuxType'('0))
   end
   // Output stage: Ready travels backwards from output side, driven by downstream circuitry
@@ -400,6 +408,7 @@ module fpnew_noncomp #(
   assign class_mask_o    = out_pipe_class_mask_q[NUM_OUT_REGS];
   assign is_class_o      = out_pipe_is_class_q[NUM_OUT_REGS];
   assign tag_o           = out_pipe_tag_q[NUM_OUT_REGS];
+  assign mask_o          = out_pipe_mask_q[NUM_OUT_REGS];
   assign aux_o           = out_pipe_aux_q[NUM_OUT_REGS];
   assign out_valid_o     = out_pipe_valid_q[NUM_OUT_REGS];
   assign busy_o          = (| {inp_pipe_valid_q, out_pipe_valid_q});

--- a/src/fpnew_opgroup_block.sv
+++ b/src/fpnew_opgroup_block.sv
@@ -24,6 +24,7 @@ module fpnew_opgroup_block #(
   parameter fpnew_pkg::fmt_unit_types_t FmtUnitTypes  = '{default: fpnew_pkg::PARALLEL},
   parameter fpnew_pkg::pipe_config_t    PipeConfig    = fpnew_pkg::BEFORE,
   parameter type                        TagType       = logic,
+  parameter int unsigned                TrueSIMDClass = 0,
   // Do not change
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
@@ -107,7 +108,8 @@ module fpnew_opgroup_block #(
         .EnableVectors ( EnableVectors                ),
         .NumPipeRegs   ( FmtPipeRegs[fmt]             ),
         .PipeConfig    ( PipeConfig                   ),
-        .TagType       ( TagType                      )
+        .TagType       ( TagType                      ),
+        .TrueSIMDClass ( TrueSIMDClass                )
       ) i_fmt_slice (
         .clk_i,
         .rst_ni,

--- a/src/fpnew_opgroup_block.sv
+++ b/src/fpnew_opgroup_block.sv
@@ -26,7 +26,9 @@ module fpnew_opgroup_block #(
   parameter type                        TagType       = logic,
   // Do not change
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
-  localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup)
+  localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
+  localparam int unsigned NUM_LANES    = fpnew_pkg::max_num_lanes(Width, FpFmtMask, EnableVectors),
+  localparam type         MaskType     = logic [NUM_LANES-1:0]
 ) (
   input logic                                     clk_i,
   input logic                                     rst_ni,
@@ -41,6 +43,7 @@ module fpnew_opgroup_block #(
   input fpnew_pkg::int_format_e                   int_fmt_i,
   input logic                                     vectorial_op_i,
   input TagType                                   tag_i,
+  input MaskType                                  simd_mask_i,
   // Input Handshake
   input  logic                                    in_valid_i,
   output logic                                    in_ready_o,
@@ -92,6 +95,11 @@ module fpnew_opgroup_block #(
 
       assign in_valid = in_valid_i & (dst_fmt_i == fmt); // enable selected format
 
+      // Forward masks related to the right SIMD lane
+      localparam int unsigned INTERNAL_LANES = fpnew_pkg::num_lanes(Width, fpnew_pkg::fp_format_e'(fmt), EnableVectors);
+      logic [INTERNAL_LANES-1:0] mask_slice;
+      always_comb for (int b = 0; b < INTERNAL_LANES; b++) mask_slice[b] = simd_mask_i[(NUM_LANES/INTERNAL_LANES)*b];
+
       fpnew_opgroup_fmt_slice #(
         .OpGroup       ( OpGroup                      ),
         .FpFormat      ( fpnew_pkg::fp_format_e'(fmt) ),
@@ -110,6 +118,7 @@ module fpnew_opgroup_block #(
         .op_mod_i,
         .vectorial_op_i,
         .tag_i,
+        .simd_mask_i    ( mask_slice               ),
         .in_valid_i     ( in_valid                 ),
         .in_ready_o     ( fmt_in_ready[fmt]        ),
         .flush_i,
@@ -183,6 +192,7 @@ module fpnew_opgroup_block #(
       .int_fmt_i,
       .vectorial_op_i,
       .tag_i,
+      .simd_mask_i     ( simd_mask_i              ),
       .in_valid_i      ( in_valid                 ),
       .in_ready_o      ( fmt_in_ready[FMT]        ),
       .flush_i,

--- a/src/fpnew_opgroup_fmt_slice.sv
+++ b/src/fpnew_opgroup_fmt_slice.sv
@@ -23,7 +23,9 @@ module fpnew_opgroup_fmt_slice #(
   parameter fpnew_pkg::pipe_config_t PipeConfig    = fpnew_pkg::BEFORE,
   parameter type                     TagType       = logic,
   // Do not change
-  localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup)
+  localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
+  localparam int unsigned NUM_LANES    = fpnew_pkg::num_lanes(Width, FpFormat, EnableVectors),
+  localparam type         MaskType     = logic [NUM_LANES-1:0]
 ) (
   input logic                               clk_i,
   input logic                               rst_ni,
@@ -35,6 +37,7 @@ module fpnew_opgroup_fmt_slice #(
   input logic                               op_mod_i,
   input logic                               vectorial_op_i,
   input TagType                             tag_i,
+  input MaskType                            simd_mask_i,
   // Input Handshake
   input  logic                              in_valid_i,
   output logic                              in_ready_o,
@@ -52,7 +55,6 @@ module fpnew_opgroup_fmt_slice #(
 );
 
   localparam int unsigned FP_WIDTH  = fpnew_pkg::fp_width(FpFormat);
-  localparam int unsigned NUM_LANES = fpnew_pkg::num_lanes(Width, FpFormat, EnableVectors);
 
 
   logic [NUM_LANES-1:0] lane_in_ready, lane_out_valid; // Handshake signals for the lanes
@@ -65,6 +67,7 @@ module fpnew_opgroup_fmt_slice #(
   logic                  [NUM_LANES-1:0] lane_ext_bit; // only the first one is actually used
   fpnew_pkg::classmask_e [NUM_LANES-1:0] lane_class_mask;
   TagType                [NUM_LANES-1:0] lane_tags; // only the first one is actually used
+  logic                  [NUM_LANES-1:0] lane_masks;
   logic                  [NUM_LANES-1:0] lane_vectorial, lane_busy, lane_is_class; // dito
 
   logic result_is_vector, result_is_class;
@@ -115,6 +118,7 @@ module fpnew_opgroup_fmt_slice #(
           .op_i,
           .op_mod_i,
           .tag_i,
+          .mask_i          ( simd_mask_i[lane]    ),
           .aux_i           ( vectorial_op         ), // Remember whether operation was vectorial
           .in_valid_i      ( in_valid             ),
           .in_ready_o      ( lane_in_ready[lane]  ),
@@ -123,6 +127,7 @@ module fpnew_opgroup_fmt_slice #(
           .status_o        ( op_status            ),
           .extension_bit_o ( lane_ext_bit[lane]   ),
           .tag_o           ( lane_tags[lane]      ),
+          .mask_o          ( lane_masks[lane]     ),
           .aux_o           ( lane_vectorial[lane] ),
           .out_valid_o     ( out_valid            ),
           .out_ready_i     ( out_ready            ),
@@ -176,6 +181,7 @@ module fpnew_opgroup_fmt_slice #(
           .op_i,
           .op_mod_i,
           .tag_i,
+          .mask_i          ( simd_mask_i[lane]     ),
           .aux_i           ( vectorial_op          ), // Remember whether operation was vectorial
           .in_valid_i      ( in_valid              ),
           .in_ready_o      ( lane_in_ready[lane]   ),
@@ -186,6 +192,7 @@ module fpnew_opgroup_fmt_slice #(
           .class_mask_o    ( lane_class_mask[lane] ),
           .is_class_o      ( lane_is_class[lane]   ),
           .tag_o           ( lane_tags[lane]       ),
+          .mask_o          ( lane_masks[lane]      ),
           .aux_o           ( lane_vectorial[lane]  ),
           .out_valid_o     ( out_valid             ),
           .out_ready_i     ( out_ready             ),
@@ -272,7 +279,7 @@ module fpnew_opgroup_fmt_slice #(
     automatic fpnew_pkg::status_t temp_status;
     temp_status = '0;
     for (int i = 0; i < int'(NUM_LANES); i++)
-      temp_status |= lane_status[i];
+      temp_status |= lane_status[i] & {5{lane_masks[i]}};
     status_o = temp_status;
   end
 endmodule

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -27,7 +27,9 @@ module fpnew_opgroup_multifmt_slice #(
   parameter type                     TagType       = logic,
   // Do not change
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
-  localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS
+  localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned NUM_SIMD_LANES = fpnew_pkg::max_num_lanes(Width, FpFmtConfig, EnableVectors),
+  localparam type         MaskType     = logic [NUM_SIMD_LANES-1:0]
 ) (
   input logic                                     clk_i,
   input logic                                     rst_ni,
@@ -42,6 +44,7 @@ module fpnew_opgroup_multifmt_slice #(
   input fpnew_pkg::int_format_e                   int_fmt_i,
   input logic                                     vectorial_op_i,
   input TagType                                   tag_i,
+  input MaskType                                  simd_mask_i,
   // Input Handshake
   input  logic                                    in_valid_i,
   output logic                                    in_ready_o,
@@ -88,6 +91,7 @@ module fpnew_opgroup_multifmt_slice #(
   fpnew_pkg::status_t [NUM_LANES-1:0]   lane_status;
   logic   [NUM_LANES-1:0]               lane_ext_bit; // only the first one is actually used
   TagType [NUM_LANES-1:0]               lane_tags; // only the first one is actually used
+  logic   [NUM_LANES-1:0]               lane_masks;
   logic   [NUM_LANES-1:0][AUX_BITS-1:0] lane_aux; // only the first one is actually used
   logic   [NUM_LANES-1:0]               lane_busy; // dito
 
@@ -215,6 +219,7 @@ module fpnew_opgroup_multifmt_slice #(
           .src_fmt_i,
           .dst_fmt_i,
           .tag_i,
+          .mask_i          ( simd_mask_i[lane]   ),
           .aux_i           ( aux_data            ),
           .in_valid_i      ( in_valid            ),
           .in_ready_o      ( lane_in_ready[lane] ),
@@ -223,6 +228,7 @@ module fpnew_opgroup_multifmt_slice #(
           .status_o        ( op_status           ),
           .extension_bit_o ( lane_ext_bit[lane]  ),
           .tag_o           ( lane_tags[lane]     ),
+          .mask_o          ( lane_masks[lane]    ),
           .aux_o           ( lane_aux[lane]      ),
           .out_valid_o     ( out_valid           ),
           .out_ready_i     ( out_ready           ),
@@ -245,6 +251,7 @@ module fpnew_opgroup_multifmt_slice #(
           .op_i,
           .dst_fmt_i,
           .tag_i,
+          .mask_i          ( simd_mask_i[lane]   ),
           .aux_i           ( aux_data            ),
           .in_valid_i      ( in_valid            ),
           .in_ready_o      ( lane_in_ready[lane] ),
@@ -253,6 +260,7 @@ module fpnew_opgroup_multifmt_slice #(
           .status_o        ( op_status           ),
           .extension_bit_o ( lane_ext_bit[lane]  ),
           .tag_o           ( lane_tags[lane]     ),
+          .mask_o          ( lane_masks[lane]    ),
           .aux_o           ( lane_aux[lane]      ),
           .out_valid_o     ( out_valid           ),
           .out_ready_i     ( out_ready           ),
@@ -280,6 +288,7 @@ module fpnew_opgroup_multifmt_slice #(
           .dst_fmt_i,
           .int_fmt_i,
           .tag_i,
+          .mask_i          ( simd_mask_i[lane]   ),
           .aux_i           ( aux_data            ),
           .in_valid_i      ( in_valid            ),
           .in_ready_o      ( lane_in_ready[lane] ),
@@ -288,6 +297,7 @@ module fpnew_opgroup_multifmt_slice #(
           .status_o        ( op_status           ),
           .extension_bit_o ( lane_ext_bit[lane]  ),
           .tag_o           ( lane_tags[lane]     ),
+          .mask_o          ( lane_masks[lane]    ),
           .aux_o           ( lane_aux[lane]      ),
           .out_valid_o     ( out_valid           ),
           .out_ready_i     ( out_ready           ),
@@ -422,7 +432,8 @@ module fpnew_opgroup_multifmt_slice #(
     automatic fpnew_pkg::status_t temp_status;
     temp_status = '0;
     for (int i = 0; i < int'(NUM_LANES); i++)
-      temp_status |= lane_status[i];
+      temp_status |= lane_status[i] & {5{lane_masks[i]}};
     status_o = temp_status;
   end
+
 endmodule

--- a/src/fpnew_pkg.sv
+++ b/src/fpnew_pkg.sv
@@ -133,6 +133,7 @@ package fpnew_pkg;
     RDN = 3'b010,
     RUP = 3'b011,
     RMM = 3'b100,
+    ROD = 3'b101,  // This mode is not defined in RISC-V FP-SPEC
     DYN = 3'b111
   } roundmode_e;
 

--- a/src/fpnew_rounding.sv
+++ b/src/fpnew_rounding.sv
@@ -32,8 +32,6 @@ module fpnew_rounding #(
 
   logic round_up; // Rounding decision
 
-  logic [AbsWidth-1:0] abs_value_rod; // For ROD
-
   // Take the rounding decision according to RISC-V spec
   // RoundMode | Mnemonic | Meaning
   // :--------:|:--------:|:-------
@@ -58,14 +56,13 @@ module fpnew_rounding #(
       fpnew_pkg::RDN: round_up = (| round_sticky_bits_i) ? sign_i  : 1'b0; // to 0 if +, away if -
       fpnew_pkg::RUP: round_up = (| round_sticky_bits_i) ? ~sign_i : 1'b0; // to 0 if -, away if +
       fpnew_pkg::RMM: round_up = round_sticky_bits_i[1]; // round down if < ulp/2 away, else up
+      fpnew_pkg::ROD: round_up = ~abs_value_i[0] & (| round_sticky_bits_i);
       default: round_up = fpnew_pkg::DONT_CARE; // propagate x
     endcase
   end
-  // For rounding towardsodd i.e logical OR b/w last bit of mantissa and sticky_bits.
-  assign abs_value_rod = {abs_value_i[AbsWidth-1:1],abs_value_i[0] || (|round_sticky_bits_i)};
 
   // Perform the rounding, exponent change and overflow to inf happens automagically
-  assign abs_rounded_o =(rnd_mode_i == fpnew_pkg::ROD)? abs_value_rod : abs_value_i + round_up;
+  assign abs_rounded_o = abs_value_i + round_up;
 
   // True zero result is a zero result without dirty round/sticky bits
   assign exact_zero_o = (abs_value_i == '0) && (round_sticky_bits_i == '0);

--- a/src/fpnew_rounding.sv
+++ b/src/fpnew_rounding.sv
@@ -32,6 +32,8 @@ module fpnew_rounding #(
 
   logic round_up; // Rounding decision
 
+  logic [AbsWidth-1:0] abs_value_rod; // For ROD
+
   // Take the rounding decision according to RISC-V spec
   // RoundMode | Mnemonic | Meaning
   // :--------:|:--------:|:-------
@@ -40,6 +42,7 @@ module fpnew_rounding #(
   //    010    |   RDN    | Round Down (towards -\infty)
   //    011    |   RUP    | Round Up (towards \infty)
   //    100    |   RMM    | Round to Nearest, ties to Max Magnitude
+  //    101    |   ROD    | Round towards odd (this mode is not define in RISC-V FP-SPEC)
   //  others   |          | *invalid*
   always_comb begin : rounding_decision
     unique case (rnd_mode_i)
@@ -58,9 +61,11 @@ module fpnew_rounding #(
       default: round_up = fpnew_pkg::DONT_CARE; // propagate x
     endcase
   end
+  // For rounding towardsodd i.e logical OR b/w last bit of mantissa and sticky_bits.
+  assign abs_value_rod = {abs_value_i[AbsWidth-1:1],abs_value_i[0] || (|round_sticky_bits_i)};
 
   // Perform the rounding, exponent change and overflow to inf happens automagically
-  assign abs_rounded_o = abs_value_i + round_up;
+  assign abs_rounded_o =(rnd_mode_i == fpnew_pkg::ROD)? abs_value_rod : abs_value_i + round_up;
 
   // True zero result is a zero result without dirty round/sticky bits
   assign exact_zero_o = (abs_value_i == '0) && (round_sticky_bits_i == '0);

--- a/src/fpnew_top.sv
+++ b/src/fpnew_top.sv
@@ -18,6 +18,8 @@ module fpnew_top #(
   parameter fpnew_pkg::fpu_features_t       Features       = fpnew_pkg::RV64D_Xsflt,
   parameter fpnew_pkg::fpu_implementation_t Implementation = fpnew_pkg::DEFAULT_NOREGS,
   parameter type                            TagType        = logic,
+  parameter int unsigned                    NumLanes       = fpnew_pkg::max_num_lanes(Features.Width, Features.FpFmtMask, Features.EnableVectors),
+  parameter type                            MaskType       = logic [NumLanes-1:0],
   // Do not change
   localparam int unsigned WIDTH        = Features.Width,
   localparam int unsigned NUM_OPERANDS = 3
@@ -34,6 +36,7 @@ module fpnew_top #(
   input fpnew_pkg::int_format_e             int_fmt_i,
   input logic                               vectorial_op_i,
   input TagType                             tag_i,
+  input MaskType                            simd_mask_i,
   // Input Handshake
   input  logic                              in_valid_i,
   output logic                              in_ready_o,
@@ -127,6 +130,7 @@ module fpnew_top #(
       .int_fmt_i,
       .vectorial_op_i,
       .tag_i,
+      .simd_mask_i     ( simd_mask_i           ),
       .in_valid_i      ( in_valid              ),
       .in_ready_o      ( opgrp_in_ready[opgrp] ),
       .flush_i,

--- a/src/fpnew_top.sv
+++ b/src/fpnew_top.sv
@@ -18,10 +18,11 @@ module fpnew_top #(
   parameter fpnew_pkg::fpu_features_t       Features       = fpnew_pkg::RV64D_Xsflt,
   parameter fpnew_pkg::fpu_implementation_t Implementation = fpnew_pkg::DEFAULT_NOREGS,
   parameter type                            TagType        = logic,
-  parameter int unsigned                    NumLanes       = fpnew_pkg::max_num_lanes(Features.Width, Features.FpFmtMask, Features.EnableVectors),
   parameter int unsigned                    TrueSIMDClass  = 0,
-  parameter type                            MaskType       = logic [NumLanes-1:0],
+  parameter int unsigned                    EnableSIMDMask = 0,
   // Do not change
+  localparam int unsigned NumLanes     = fpnew_pkg::max_num_lanes(Features.Width, Features.FpFmtMask, Features.EnableVectors),
+  localparam type         MaskType     = logic [NumLanes-1:0],
   localparam int unsigned WIDTH        = Features.Width,
   localparam int unsigned NUM_OPERANDS = 3
 ) (
@@ -91,6 +92,10 @@ module fpnew_top #(
     end
   end
 
+  // Filter out the mask if not used
+  MaskType simd_mask;
+  assign simd_mask = simd_mask_i | ~{NumLanes{logic'(EnableSIMDMask)}};
+
   // -------------------------
   // Generate Operation Blocks
   // -------------------------
@@ -132,7 +137,7 @@ module fpnew_top #(
       .int_fmt_i,
       .vectorial_op_i,
       .tag_i,
-      .simd_mask_i     ( simd_mask_i           ),
+      .simd_mask_i     ( simd_mask             ),
       .in_valid_i      ( in_valid              ),
       .in_ready_o      ( opgrp_in_ready[opgrp] ),
       .flush_i,

--- a/src/fpnew_top.sv
+++ b/src/fpnew_top.sv
@@ -19,6 +19,7 @@ module fpnew_top #(
   parameter fpnew_pkg::fpu_implementation_t Implementation = fpnew_pkg::DEFAULT_NOREGS,
   parameter type                            TagType        = logic,
   parameter int unsigned                    NumLanes       = fpnew_pkg::max_num_lanes(Features.Width, Features.FpFmtMask, Features.EnableVectors),
+  parameter int unsigned                    TrueSIMDClass  = 0,
   parameter type                            MaskType       = logic [NumLanes-1:0],
   // Do not change
   localparam int unsigned WIDTH        = Features.Width,
@@ -116,7 +117,8 @@ module fpnew_top #(
       .FmtPipeRegs   ( Implementation.PipeRegs[opgrp]  ),
       .FmtUnitTypes  ( Implementation.UnitTypes[opgrp] ),
       .PipeConfig    ( Implementation.PipeConfig       ),
-      .TagType       ( TagType                         )
+      .TagType       ( TagType                         ),
+      .TrueSIMDClass ( TrueSIMDClass                   )
     ) i_opgroup_block (
       .clk_i,
       .rst_ni,


### PR DESCRIPTION
Hello everyone, 

This PR follows the discussions we had around reducing the entropy that exists among our projects. 
We have many different versions of `cva6` and `fpnew` around, and we are trying to converge.

As discussed here https://github.com/openhwgroup/cva6/pull/1102, this PR aims to merge into the `main` branch (`develop`?) the fixes and light modifications introduced to better support the RISC-V V extension. 
Thus far, these modifications were only used in the Ara system (https://github.com/pulp-platform/ara).

The modifications include the following:
1) Fix bug triggered by vectorial divisions/sqrts.
2) Add support for RISC-V-compliant classify when the width of the vector elements is at least 10 bits.
3) Add a `mask` input signal to mask the exceptions from inactive SIMD elements.
4) Add support for rounding toward odd.

Feel free to let me know if you need additional details!