### PR TITLE
Fix width of third local operand of multifmt slice

### DIFF
--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -179,10 +179,11 @@ module fpnew_opgroup_multifmt_slice #(
       // Slice out the operands for this lane, upper bits are ignored in the unit
       always_comb begin : prepare_input
         for (int unsigned i = 0; i < NUM_OPERANDS; i++) begin
-          local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(src_fmt_i);
-        end
-        if (NUM_OPERANDS == 3) begin
-          local_operands[NUM_OPERANDS-1] = operands_i[NUM_OPERANDS-1] >> LANE*fpnew_pkg::fp_width(dst_fmt_i);
+          if (i == 2) begin
+            local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(dst_fmt_i);
+          end else begin
+            local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(src_fmt_i);
+          end
         end
 
         // override operand 0 for some conversions

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -181,6 +181,9 @@ module fpnew_opgroup_multifmt_slice #(
         for (int unsigned i = 0; i < NUM_OPERANDS; i++) begin
           local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(src_fmt_i);
         end
+        if (NUM_OPERANDS == 3) begin
+          local_operands[NUM_OPERANDS-1] = operands_i[NUM_OPERANDS-1] >> LANE*fpnew_pkg::fp_width(dst_fmt_i);
+        end
 
         // override operand 0 for some conversions
         if (OpGroup == fpnew_pkg::CONV) begin


### PR DESCRIPTION
Hi,

this is a proposal to fix #86 by using the width of FP format `dst_fmt_i` for assigning the third local operand in the `fpnew_opgroup_multifmt_slice`.

With this patch the operands of the individual `fpnew_fma_multi` instances are assigned correctly, as shown in the waveform below.

![fpnew_fix_annotated](https://user-images.githubusercontent.com/9446837/232730397-011c2016-0a6e-4b9d-a1cd-646eec324508.png)