### PR TITLE
:wrench: Add external reg enable to slices

### DIFF
--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -57,7 +57,9 @@ module fpnew_cast_multi #(
   output logic                   out_valid_o,
   input  logic                   out_ready_i,
   // Indication of valid data in flight
-  output logic                   busy_o
+  output logic                   busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0] reg_ena_i
 );
 
   // ----------
@@ -150,7 +152,7 @@ module fpnew_cast_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_is_boxed_q[i+1], inp_pipe_is_boxed_q[i], reg_ena, '0)
@@ -373,7 +375,7 @@ module fpnew_cast_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(mid_pipe_valid_q[i+1], mid_pipe_valid_q[i], mid_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = mid_pipe_ready[i] & mid_pipe_valid_q[i];
+    assign reg_ena = (mid_pipe_ready[i] & mid_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(mid_pipe_input_sign_q[i+1], mid_pipe_input_sign_q[i], reg_ena, '0)
     `FFL(mid_pipe_input_exp_q[i+1],  mid_pipe_input_exp_q[i],  reg_ena, '0)
@@ -771,7 +773,7 @@ module fpnew_cast_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + NUM_MID_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1],  out_pipe_result_q[i],  reg_ena, '0)
     `FFL(out_pipe_status_q[i+1],  out_pipe_status_q[i],  reg_ena, '0)

--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -26,7 +26,8 @@ module fpnew_cast_multi #(
   // Do not change
   localparam int unsigned WIDTH = fpnew_pkg::maximum(fpnew_pkg::max_fp_width(FpFmtConfig),
                                                      fpnew_pkg::max_int_width(IntFmtConfig)),
-  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS
+  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input  logic                   clk_i,
   input  logic                   rst_ni,
@@ -59,7 +60,7 @@ module fpnew_cast_multi #(
   // Indication of valid data in flight
   output logic                   busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0] reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0] reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -56,7 +56,9 @@ module fpnew_divsqrt_multi #(
   output logic                        out_valid_o,
   input  logic                        out_ready_i,
   // Indication of valid data in flight
-  output logic                        busy_o
+  output logic                        busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]      reg_ena_i
 );
 
   // ----------
@@ -118,7 +120,7 @@ module fpnew_divsqrt_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_rnd_mode_q[i+1], inp_pipe_rnd_mode_q[i], reg_ena, fpnew_pkg::RNE)
@@ -344,7 +346,7 @@ module fpnew_divsqrt_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)

--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -24,7 +24,8 @@ module fpnew_divsqrt_multi #(
   parameter type                     AuxType     = logic,
   // Do not change
   localparam int unsigned WIDTH       = fpnew_pkg::max_fp_width(FpFmtConfig),
-  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS
+  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input  logic                        clk_i,
   input  logic                        rst_ni,
@@ -58,7 +59,7 @@ module fpnew_divsqrt_multi #(
   // Indication of valid data in flight
   output logic                        busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]      reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0]   reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_divsqrt_th_32.sv
+++ b/src/fpnew_divsqrt_th_32.sv
@@ -27,7 +27,8 @@ module fpnew_divsqrt_th_32 #(
   parameter type                     AuxType     = logic,
   // Do not change
   localparam int unsigned WIDTH       = 32,
-  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS
+  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input  logic                        clk_i,
   input  logic                        rst_ni,
@@ -56,7 +57,7 @@ module fpnew_divsqrt_th_32 #(
   // Indication of valid data in flight
   output logic                        busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]      reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0]   reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_divsqrt_th_32.sv
+++ b/src/fpnew_divsqrt_th_32.sv
@@ -54,7 +54,9 @@ module fpnew_divsqrt_th_32 #(
   output logic                        out_valid_o,
   input  logic                        out_ready_i,
   // Indication of valid data in flight
-  output logic                        busy_o
+  output logic                        busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]      reg_ena_i
 );
 
   // ----------
@@ -113,7 +115,7 @@ module fpnew_divsqrt_th_32 #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_rnd_mode_q[i+1], inp_pipe_rnd_mode_q[i], reg_ena, fpnew_pkg::RNE)
@@ -454,7 +456,7 @@ module fpnew_divsqrt_th_32 #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)

--- a/src/fpnew_fma.sv
+++ b/src/fpnew_fma.sv
@@ -50,7 +50,9 @@ module fpnew_fma #(
   output logic                     out_valid_o,
   input  logic                     out_ready_i,
   // Indication of valid data in flight
-  output logic                     busy_o
+  output logic                     busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]   reg_ena_i
 );
 
   // ----------
@@ -135,7 +137,7 @@ module fpnew_fma #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_is_boxed_q[i+1], inp_pipe_is_boxed_q[i], reg_ena, '0)
@@ -450,7 +452,7 @@ module fpnew_fma #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(mid_pipe_valid_q[i+1], mid_pipe_valid_q[i], mid_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = mid_pipe_ready[i] & mid_pipe_valid_q[i];
+    assign reg_ena = (mid_pipe_ready[i] & mid_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(mid_pipe_eff_sub_q[i+1],     mid_pipe_eff_sub_q[i],     reg_ena, '0)
     `FFL(mid_pipe_exp_prod_q[i+1],    mid_pipe_exp_prod_q[i],    reg_ena, '0)
@@ -668,7 +670,7 @@ module fpnew_fma #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + NUM_MID_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)

--- a/src/fpnew_fma.sv
+++ b/src/fpnew_fma.sv
@@ -21,8 +21,9 @@ module fpnew_fma #(
   parameter fpnew_pkg::pipe_config_t PipeConfig  = fpnew_pkg::BEFORE,
   parameter type                     TagType     = logic,
   parameter type                     AuxType     = logic,
-
-  localparam int unsigned WIDTH = fpnew_pkg::fp_width(FpFormat) // do not change
+  // Do not change
+  localparam int unsigned WIDTH = fpnew_pkg::fp_width(FpFormat),
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input logic                      clk_i,
   input logic                      rst_ni,
@@ -52,7 +53,7 @@ module fpnew_fma #(
   // Indication of valid data in flight
   output logic                     busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]   reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0] reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -23,7 +23,8 @@ module fpnew_fma_multi #(
   parameter type                     AuxType     = logic,
   // Do not change
   localparam int unsigned WIDTH       = fpnew_pkg::max_fp_width(FpFmtConfig),
-  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS
+  localparam int unsigned NUM_FORMATS = fpnew_pkg::NUM_FP_FORMATS,
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input  logic                        clk_i,
   input  logic                        rst_ni,
@@ -55,7 +56,7 @@ module fpnew_fma_multi #(
   // Indication of valid data in flight
   output logic                        busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]      reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0]   reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -53,7 +53,9 @@ module fpnew_fma_multi #(
   output logic                        out_valid_o,
   input  logic                        out_ready_i,
   // Indication of valid data in flight
-  output logic                        busy_o
+  output logic                        busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]      reg_ena_i
 );
 
   // ----------
@@ -150,7 +152,7 @@ module fpnew_fma_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_is_boxed_q[i+1], inp_pipe_is_boxed_q[i], reg_ena, '0)
@@ -536,7 +538,7 @@ module fpnew_fma_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(mid_pipe_valid_q[i+1], mid_pipe_valid_q[i], mid_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = mid_pipe_ready[i] & mid_pipe_valid_q[i];
+    assign reg_ena = (mid_pipe_ready[i] & mid_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(mid_pipe_eff_sub_q[i+1],     mid_pipe_eff_sub_q[i],     reg_ena, '0)
     `FFL(mid_pipe_exp_prod_q[i+1],    mid_pipe_exp_prod_q[i],    reg_ena, '0)
@@ -817,7 +819,7 @@ module fpnew_fma_multi #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + NUM_MID_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1], out_pipe_result_q[i], reg_ena, '0)
     `FFL(out_pipe_status_q[i+1], out_pipe_status_q[i], reg_ena, '0)

--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -21,8 +21,9 @@ module fpnew_noncomp #(
   parameter fpnew_pkg::pipe_config_t PipeConfig  = fpnew_pkg::BEFORE,
   parameter type                     TagType     = logic,
   parameter type                     AuxType     = logic,
-
-  localparam int unsigned WIDTH = fpnew_pkg::fp_width(FpFormat) // do not change
+  // Do not change
+  localparam int unsigned WIDTH = fpnew_pkg::fp_width(FpFormat),
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input logic                  clk_i,
   input logic                  rst_ni,
@@ -54,7 +55,7 @@ module fpnew_noncomp #(
   // Indication of valid data in flight
   output logic                     busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]   reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0] reg_ena_i
 );
 
   // ----------

--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -52,7 +52,9 @@ module fpnew_noncomp #(
   output logic                     out_valid_o,
   input  logic                     out_ready_i,
   // Indication of valid data in flight
-  output logic                     busy_o
+  output logic                     busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]   reg_ena_i
 );
 
   // ----------
@@ -120,7 +122,7 @@ module fpnew_noncomp #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(inp_pipe_valid_q[i+1], inp_pipe_valid_q[i], inp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = inp_pipe_ready[i] & inp_pipe_valid_q[i];
+    assign reg_ena = (inp_pipe_ready[i] & inp_pipe_valid_q[i]) | reg_ena_i[i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(inp_pipe_operands_q[i+1], inp_pipe_operands_q[i], reg_ena, '0)
     `FFL(inp_pipe_is_boxed_q[i+1], inp_pipe_is_boxed_q[i], reg_ena, '0)
@@ -388,7 +390,7 @@ module fpnew_noncomp #(
     // Valid: enabled by ready signal, synchronous clear with the flush signal
     `FFLARNC(out_pipe_valid_q[i+1], out_pipe_valid_q[i], out_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
     // Enable register if pipleine ready and a valid data item is present
-    assign reg_ena = out_pipe_ready[i] & out_pipe_valid_q[i];
+    assign reg_ena = (out_pipe_ready[i] & out_pipe_valid_q[i]) | reg_ena_i[NUM_INP_REGS + i];
     // Generate the pipeline registers within the stages, use enable-registers
     `FFL(out_pipe_result_q[i+1],        out_pipe_result_q[i],        reg_ena, '0)
     `FFL(out_pipe_status_q[i+1],        out_pipe_status_q[i],        reg_ena, '0)

--- a/src/fpnew_opgroup_block.sv
+++ b/src/fpnew_opgroup_block.sv
@@ -131,7 +131,8 @@ module fpnew_opgroup_block #(
         .tag_o          ( fmt_outputs[fmt].tag     ),
         .out_valid_o    ( fmt_out_valid[fmt]       ),
         .out_ready_i    ( fmt_out_ready[fmt]       ),
-        .busy_o         ( fmt_busy[fmt]            )
+        .busy_o         ( fmt_busy[fmt]            ),
+        .reg_ena_i      ( '0                       )
       );
     // If the format wants to use merged ops, tie off the dangling ones not used here
     end else if (FpFmtMask[fmt] && ANY_MERGED && !IS_FIRST_MERGED) begin : merged_unused
@@ -206,7 +207,8 @@ module fpnew_opgroup_block #(
       .tag_o           ( fmt_outputs[FMT].tag     ),
       .out_valid_o     ( fmt_out_valid[FMT]       ),
       .out_ready_i     ( fmt_out_ready[FMT]       ),
-      .busy_o          ( fmt_busy[FMT]            )
+      .busy_o          ( fmt_busy[FMT]            ),
+      .reg_ena_i       ( '0                       )
     );
 
   end

--- a/src/fpnew_opgroup_fmt_slice.sv
+++ b/src/fpnew_opgroup_fmt_slice.sv
@@ -27,7 +27,8 @@ module fpnew_opgroup_fmt_slice #(
   // Do not change
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
   localparam int unsigned NUM_LANES    = fpnew_pkg::num_lanes(Width, FpFormat, EnableVectors),
-  localparam type         MaskType     = logic [NUM_LANES-1:0]
+  localparam type         MaskType     = logic [NUM_LANES-1:0],
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input logic                               clk_i,
   input logic                               rst_ni,
@@ -55,7 +56,7 @@ module fpnew_opgroup_fmt_slice #(
   // Indication of valid data in flight
   output logic                              busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]            reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0]         reg_ena_i
 );
 
   localparam int unsigned FP_WIDTH  = fpnew_pkg::fp_width(FpFormat);

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -31,7 +31,8 @@ module fpnew_opgroup_multifmt_slice #(
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
   localparam int unsigned NUM_FORMATS  = fpnew_pkg::NUM_FP_FORMATS,
   localparam int unsigned NUM_SIMD_LANES = fpnew_pkg::max_num_lanes(Width, FpFmtConfig, EnableVectors),
-  localparam type         MaskType     = logic [NUM_SIMD_LANES-1:0]
+  localparam type         MaskType     = logic [NUM_SIMD_LANES-1:0],
+  localparam int unsigned ExtRegEnaWidth = NumPipeRegs == 0 ? 1 : NumPipeRegs
 ) (
   input logic                                     clk_i,
   input logic                                     rst_ni,
@@ -62,7 +63,7 @@ module fpnew_opgroup_multifmt_slice #(
   // Indication of valid data in flight
   output logic                                    busy_o,
   // External register enable override
-  input  logic [NumPipeRegs-1:0]                  reg_ena_i
+  input  logic [ExtRegEnaWidth-1:0]               reg_ena_i
 );
 
   if ((OpGroup == fpnew_pkg::DIVSQRT) && !PulpDivsqrt &&

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -317,7 +317,8 @@ or set Features.FpFmtMask to support only FP32");
             .aux_o            ( lane_aux[lane]      ),
             .out_valid_o      ( out_valid           ),
             .out_ready_i      ( out_ready           ),
-            .busy_o           ( lane_busy[lane]     )
+            .busy_o           ( lane_busy[lane]     ),
+            .reg_ena_i
           );
         end
       end else if (OpGroup == fpnew_pkg::NONCOMP) begin : lane_instance

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -25,6 +25,7 @@ module fpnew_opgroup_multifmt_slice #(
   parameter logic                    PulpDivsqrt   = 1'b1,
   parameter int unsigned             NumPipeRegs   = 0,
   parameter fpnew_pkg::pipe_config_t PipeConfig    = fpnew_pkg::BEFORE,
+  parameter logic                    ExtRegEna     = 1'b0,
   parameter type                     TagType       = logic,
   // Do not change
   localparam int unsigned NUM_OPERANDS = fpnew_pkg::num_operands(OpGroup),
@@ -59,7 +60,9 @@ module fpnew_opgroup_multifmt_slice #(
   output logic                                    out_valid_o,
   input  logic                                    out_ready_i,
   // Indication of valid data in flight
-  output logic                                    busy_o
+  output logic                                    busy_o,
+  // External register enable override
+  input  logic [NumPipeRegs-1:0]                  reg_ena_i
 );
 
   if ((OpGroup == fpnew_pkg::DIVSQRT) && !PulpDivsqrt &&
@@ -244,7 +247,8 @@ or set Features.FpFmtMask to support only FP32");
           .aux_o           ( lane_aux[lane]      ),
           .out_valid_o     ( out_valid           ),
           .out_ready_i     ( out_ready           ),
-          .busy_o          ( lane_busy[lane]     )
+          .busy_o          ( lane_busy[lane]     ),
+          .reg_ena_i
         );
 
       end else if (OpGroup == fpnew_pkg::DIVSQRT) begin : lane_instance
@@ -276,7 +280,8 @@ or set Features.FpFmtMask to support only FP32");
             .aux_o           ( lane_aux[lane]      ),
             .out_valid_o     ( out_valid           ),
             .out_ready_i     ( out_ready           ),
-            .busy_o          ( lane_busy[lane]     )
+            .busy_o          ( lane_busy[lane]     ),
+            .reg_ena_i
           );
         end else begin
           fpnew_divsqrt_multi #(
@@ -349,7 +354,8 @@ or set Features.FpFmtMask to support only FP32");
           .aux_o           ( lane_aux[lane]      ),
           .out_valid_o     ( out_valid           ),
           .out_ready_i     ( out_ready           ),
-          .busy_o          ( lane_busy[lane]     )
+          .busy_o          ( lane_busy[lane]     ),
+          .reg_ena_i
         );
       end // ADD OTHER OPTIONS HERE
 
@@ -358,8 +364,8 @@ or set Features.FpFmtMask to support only FP32");
       assign lane_out_valid[lane] = out_valid & ((lane == 0) | result_is_vector);
 
       // Properly NaN-box or sign-extend the slice result if not in use
-      assign local_result      = lane_out_valid[lane] ? op_result : '{default: lane_ext_bit[0]};
-      assign lane_status[lane] = lane_out_valid[lane] ? op_status : '0;
+      assign local_result      = (lane_out_valid[lane] | ExtRegEna) ? op_result : '{default: lane_ext_bit[0]};
+      assign lane_status[lane] = (lane_out_valid[lane] | ExtRegEna) ? op_status : '0;
 
     // Otherwise generate constant sign-extension
     end else begin : inactive_lane
@@ -443,7 +449,7 @@ or set Features.FpFmtMask to support only FP32");
       // Valid: enabled by ready signal, synchronous clear with the flush signal
       `FFLARNC(byp_pipe_valid_q[i+1], byp_pipe_valid_q[i], byp_pipe_ready[i], flush_i, 1'b0, clk_i, rst_ni)
       // Enable register if pipleine ready and a valid data item is present
-      assign reg_ena = byp_pipe_ready[i] & byp_pipe_valid_q[i];
+      assign reg_ena = (byp_pipe_ready[i] & byp_pipe_valid_q[i]) | reg_ena_i[i];
       // Generate the pipeline registers within the stages, use enable-registers
       `FFL(byp_pipe_target_q[i+1],  byp_pipe_target_q[i],  reg_ena, '0)
       `FFL(byp_pipe_aux_q[i+1],     byp_pipe_aux_q[i],     reg_ena, '0)


### PR DESCRIPTION
Hi,

this PR is a proposal to add an external register enable, overriding the local register enables generated from the internal `valid` and `ready` handshake signals, to the slice modules (`fpnew_opgroup_[multi]fmt_slice`) and the underlying opgroup modules.

The motivation for an external register enable is a better separation between control flow and data flow. Concretely, an external register enable would allow for the following:
- When a CVFPU slice module is instantiated as part of an ALU pipeline that also hosts another unit, such as an integer ALU, the external register enable can be used to avoid splitting the pipeline into an integer and a floating-point part and then merging them back together, but instead allows to control the individual pipeline stages of the CVFPU opgroups as well as the integer pipeline stages with a single main pipeline. This also solves the problem of re-ordering the output of individual pipeline branches in case the pipeline requires all operations to remain in order.
- An external register enable allows to run the control logic ahead of the dataflow, with the register enable signals passing through one or several FF buffers, which may help timing closure by separating the often critical `ready` signal path from the register enables of the FFs in the dataflow path.

The changes are intended to be as minimal as possible, with an additional `reg_ena_i` port added to the slice modules and each opgroup module, which supplies the external register enable signals. This input port can be tied to `'0` if the external register enable shall not be used. Otherwise, the external register enable signals can be provided via this port and the `in_valid_i` be tied to `'0` to disable the local register enables generated by the internal handshake signals.

The width of this `reg_ena_i` port corresponds to the number of pipeline stages - however, an additional parameter `ExtRegEnaWidth` is required to catch the case where the number of stages is 0. Finally, the slice modules also gained a parameter `ExtRegEna` which must be set to `1'b1` to avoid Nan-boxing all outputs in the absence of internal valid signals.

Note that the external register enables are only available when directly instantiating the `fpnew_opgroup_[multi]fmt_slice` modules or an individual opgroup module. The `fpnew_opgroup_block` disables the external register enables by tying `reg_ena_i` to `'0` and leaving the `ExtRegEna` at its default value of `1'b0`. We have used the formality tool to verify that instantiating `fpnew_top` with these changes is still *formally equivalent* (using Synopsys formality) to the same instantiation without these changes.